### PR TITLE
docs: Create CODE_OF_CONDUCT.md and CONTRIBUTING.md 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+Please also take a moment to review [MongoDB's core values][mdb-core-values].
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team, or by
+[contacting GitHub][github-report-abuse]. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version [1.4][version].
+
+
+[github-report-abuse]: https://github.com/contact/report-abuse
+[homepage]: https://www.contributor-covenant.org/
+[mdb-core-values]: https://www.mongodb.com/company/
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This helps the team automate [CHANGELOG.md][changelog] generation.
 ## Pull Request Process
 
 1. Update the README.md or similar documentation with details of changes you
-   wish to make.
+   wish to make, if applicable. 
 2. Add any appropriate tests.
 3. Make your code or other changes.
 4. Review guidelines such as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+pull request, or any other method with the owners of this repository before making a change. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Commit messages
+
+Please follow the [Angular commit style][angular-commit-style]. 
+This helps the team automate [CHANGELOG.md](CHANGELOG.md) generation.
+
+## Pull Request Process
+
+1. Update the README.md or similar documentation with details of changes you wish to make.
+2. Add any appropriate tests.
+3. Make your code or other changes.
+4. Review guidelines such as [How to write the perfect pull request][github-perfect-pr], thanks!
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation. Please also take a moment to review [MongoDB's core values][mdb-core-values].
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team, or by [contacting GitHub][github-report-abuse]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version [1.4][version].
+
+[angular-commit-style]: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
+[github-perfect-pr]: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
+[github-report-abuse]: https://github.com/contact/report-abuse
+[homepage]: https://www.contributor-covenant.org/
+[mdb-core-values]: https://www.mongodb.com/company/
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,96 +1,29 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-pull request, or any other method with the owners of this repository before making a change. 
+When contributing to this repository, please first discuss the change you wish
+to make via issue, pull request, or any other method with the owners of this
+repository before making a change.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a [code of conduct][code-of-conduct],
+please follow it in all your interactions with the project.
 
 ## Commit messages
 
-Please follow the [Angular commit style][angular-commit-style]. 
-This helps the team automate [CHANGELOG.md](CHANGELOG.md) generation.
+Please follow the [Angular commit style][angular-commit-style].
+This helps the team automate [CHANGELOG.md][changelog] generation.
 
 ## Pull Request Process
 
-1. Update the README.md or similar documentation with details of changes you wish to make.
+1. Update the README.md or similar documentation with details of changes you
+   wish to make.
 2. Add any appropriate tests.
 3. Make your code or other changes.
-4. Review guidelines such as [How to write the perfect pull request][github-perfect-pr], thanks!
+4. Review guidelines such as
+   [How to write the perfect pull request][github-perfect-pr], thanks!
 
-## Code of Conduct
-
-### Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation. Please also take a moment to review [MongoDB's core values][mdb-core-values].
-
-### Our Standards
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-### Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-### Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team, or by [contacting GitHub][github-report-abuse]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-### Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version [1.4][version].
 
 [angular-commit-style]: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
+[changelog]: CHANGELOG.md
+[code-of-conduct]: CODE_OF_CONDUCT.md
 [github-perfect-pr]: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
-[github-report-abuse]: https://github.com/contact/report-abuse
-[homepage]: https://www.contributor-covenant.org/
 [mdb-core-values]: https://www.mongodb.com/company/
-[version]: https://www.contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md and a CONTRIBUTING.md.

I think it is not a decision to be made lightly. Please read: https://www.contributor-covenant.org/

This was inspired by https://github.com/mongodb-js/mongodb-extjson/pull/10#issuecomment-377234553

P.S. Happy Easter everyone. If one has any wish, such as 🥚 or 🐰 I hope such dreams come to life for you. CC @rueckstiess 