### PR TITLE
Don't cast to Double in non-strict mode

### DIFF
--- a/lib/ext_json.js
+++ b/lib/ext_json.js
@@ -56,7 +56,7 @@ function deserializeValue(self, key, value, options) {
       if (int64Range) return options.strict ? new BSON.Long.fromNumber(value) : value;
     }
     // If the number is a non-integer or out of integer range, should interpret as BSON Double.
-    return new BSON.Double(value);
+    return options.strict ? new BSON.Double(value) : value;
   }
 
   // from here on out we're looking for bson types, so bail if its not an object

--- a/test/extend_mongodb_tests.js
+++ b/test/extend_mongodb_tests.js
@@ -83,20 +83,30 @@ describe('Extended JSON', function() {
   it('should correctly serialize, and deserialize using built-in BSON', function() {
     // Create ExtJSON instance
     var Int32 = extJSON.BSON.Int32;
+    var Long = extJSON.BSON.Long;
+    var Double = extJSON.BSON.Double;
+
     // Create a doc
     var doc1 = {
-      int32: new Int32(10)
+      int32: new Int32(10),
+      long: new Long(100),
+      double: new Double(10.1)
     };
 
     // Serialize the document
     var text = extJSON.stringify(doc1, null, 0);
-    expect(text).to.equal('{"int32":{"$numberInt":"10"}}');
+    expect(text).to.equal('{"int32":{"$numberInt":"10"},"long":{"$numberLong":"100"},"double":{"$numberDouble":"10.1"}}');
 
     // Deserialize the json in strict and non strict mode
     var doc2 = extJSON.parse(text, { strict: true });
     expect(doc2.int32._bsontype).to.equal('Int32');
+    expect(doc2.long._bsontype).to.equal('Long');
+    expect(doc2.double._bsontype).to.equal('Double');
+
     doc2 = extJSON.parse(text, { strict: false });
     expect(doc2.int32).to.equal(10);
+    expect(doc2.long).to.equal(100);
+    expect(doc2.double).to.equal(10.1);
   });
 
   it('should correctly serialize bson types when they are values', function() {


### PR DESCRIPTION
Hi,

 I'm facing the issue and need to fix this.

MongoDB node.js driver will store JavaScript Number as Double type by default.
So I think parsing in non-strict mode, Double should cast to number.

Furthermore, JavaScript numbers are always stored as double precision floating point numbers, following the IEEE 754 standard.